### PR TITLE
better webhook regex

### DIFF
--- a/matchers/webhook.py
+++ b/matchers/webhook.py
@@ -9,7 +9,7 @@ class Webhook(Matcher):
 
     def find(self) -> List[Tuple[int, str, str]]:
         self.regex = re.compile(
-            r'((:?https:\/\/(:?.*\.)discord.*?)\d{18}?[^[a-z0-9\-_][a-z0-9\-_]{68})',
+            r'(https?:\/\/(ptb\.|canary\.)?discord(app)?\.com\/api\/webhooks\/\d{18}\/[\w\-]{68})',
         )
 
         return self._find(


### PR DESCRIPTION
```
(https?:\/\/(ptb\.|canary\.)?discord(app)?\.com\/api\/webhooks\/\d{18}\/[\w\-]{68})
```